### PR TITLE
Stream file in byte mode, since the default line mode corrupts binary files

### DIFF
--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -35,7 +35,7 @@ defmodule Multipart.Part do
   @spec file_body(String.t(), headers()) :: t()
   def file_body(path, headers \\ []) do
     %File.Stat{size: size} = File.stat!(path)
-    file_stream = File.stream!(path)
+    file_stream = File.stream!(path, [{:read_ahead, 4096}], 1024)
 
     %__MODULE__{body: file_stream, content_length: size, headers: headers}
   end

--- a/test/files/test-crlf.txt
+++ b/test/files/test-crlf.txt
@@ -1,0 +1,3 @@
+Hello, this is a test of a CRLF file.
+
+This is another line.

--- a/test/multipart_test.exs
+++ b/test/multipart_test.exs
@@ -77,6 +77,23 @@ defmodule MultipartTest do
     assert content_length == String.length(expected_output)
   end
 
+  test "building a message preserves original line breaks" do
+    multipart =
+      Multipart.new(@boundary)
+      |> Multipart.add_part(Part.file_field(file_path("files/test-crlf.txt"), "text"))
+
+    output = Multipart.body_binary(multipart)
+
+    header =
+      "\r\n--#{@boundary}\r\ncontent-type: text/plain\r\ncontent-disposition: form-data; name=\"text\"; filename=\"test-crlf.txt\"\r\n\r\n"
+
+    body = File.read!(file_path("files/test-crlf.txt"))
+    footer = "\r\n--#{@boundary}--\r\n"
+
+    expected_output = header <> body <> footer
+    assert output == expected_output
+  end
+
   defp file_path(path) do
     Path.join(__DIR__, path)
   end


### PR DESCRIPTION
Using `File.stream!` without opts results in the default reading mode of `:line`, this simply corrupts binary files, since when using the :line option, CRLF line breaks (" ") are normalized to LF (" ") (ref: https://hexdocs.pm/elixir/1.12/File.html#stream!/3)

Discovered that when using multipart to encode small images (corrupt images and different checksums9

With the proposed change, we read in byte mode, that fixes the issue.

About the bytes read and the :read_ahead option value, I've choosen some reasonable defaults, basically is streaming 1k bytes on each iteration, but reading up to 4k from files, this allows faster reading in loops while keeping the iteration not too big.