### PR TITLE
I think content-length should be in octets

### DIFF
--- a/lib/multipart.ex
+++ b/lib/multipart.ex
@@ -93,7 +93,7 @@ defmodule Multipart do
     final_delimiter_length =
       final_delimiter(boundary)
       |> Enum.join("")
-      |> String.length()
+      |> octet_length()
 
     parts
     |> Enum.with_index()
@@ -109,6 +109,14 @@ defmodule Multipart do
     |> Kernel.+(final_delimiter_length)
   end
 
+  @doc """
+  Compute the length of a string in octets as per https://httpwg.org/specs/rfc7230.html#header.content-length
+  """
+  @spec octet_length(String.t()) :: pos_integer()
+  def octet_length(str) do
+    length(String.codepoints(str))
+  end
+
   defp part_stream(%Part{} = part, boundary) do
     Stream.concat([part_delimiter(boundary), part_headers(part), part_body_stream(part)])
   end
@@ -117,7 +125,7 @@ defmodule Multipart do
     if is_integer(content_length) do
       Enum.concat(part_delimiter(boundary), part_headers(part))
       |> Enum.reduce(0, fn str, acc ->
-        String.length(str) + acc
+        octet_length(str) + acc
       end)
       |> Kernel.+(content_length)
     else
@@ -161,4 +169,5 @@ defmodule Multipart do
 
     "==#{token}=="
   end
+
 end

--- a/lib/multipart.ex
+++ b/lib/multipart.ex
@@ -169,5 +169,4 @@ defmodule Multipart do
 
     "==#{token}=="
   end
-
 end

--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -22,7 +22,7 @@ defmodule Multipart.Part do
   """
   @spec binary_body(binary(), headers()) :: t()
   def binary_body(body, headers \\ []) when is_binary(body) do
-    content_length = String.length(body)
+    content_length = Multipart.octet_length(body)
     %__MODULE__{body: body, content_length: content_length, headers: headers}
   end
 

--- a/test/multipart_test.exs
+++ b/test/multipart_test.exs
@@ -102,5 +102,4 @@ defmodule MultipartTest do
   defp file_path(path) do
     Path.join(__DIR__, path)
   end
-
 end

--- a/test/multipart_test.exs
+++ b/test/multipart_test.exs
@@ -19,7 +19,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == Multipart.octet_length(expected_output)
   end
 
   test "building a message of file parts" do
@@ -34,7 +34,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == Multipart.octet_length(expected_output)
   end
 
   test "building a message of text form-data parts" do
@@ -49,7 +49,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == Multipart.octet_length(expected_output)
   end
 
   test "building a message of file form-data parts" do
@@ -74,7 +74,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == Multipart.octet_length(expected_output)
   end
 
   test "building a message preserves original line breaks" do
@@ -94,7 +94,13 @@ defmodule MultipartTest do
     assert output == expected_output
   end
 
+  test "counting octets correctly" do
+    str = "abc\r\n"
+    assert Multipart.octet_length(str) == 5
+  end
+
   defp file_path(path) do
     Path.join(__DIR__, path)
   end
+
 end


### PR DESCRIPTION
 According to https://httpwg.org/specs/rfc7230.html#header.content-length content length should be the number of octets in the payload. Elixir's `String. length/1` counts the number of UTF-8 graphemes, which may or may not be the same. 

I added a function `octet_length/1` to return the number of `String.codepoints/1`  and replaced the calls to `String.length/1` with calls to `octet_length/1`

Thanks for a great library to simplify creating multipart post requests.