### PR TITLE
Use bytes for Content-length

### DIFF
--- a/lib/multipart.ex
+++ b/lib/multipart.ex
@@ -93,7 +93,7 @@ defmodule Multipart do
     final_delimiter_length =
       final_delimiter(boundary)
       |> Enum.join("")
-      |> String.length()
+      |> byte_size()
 
     parts
     |> Enum.with_index()
@@ -117,7 +117,7 @@ defmodule Multipart do
     if is_integer(content_length) do
       Enum.concat(part_delimiter(boundary), part_headers(part))
       |> Enum.reduce(0, fn str, acc ->
-        String.length(str) + acc
+        byte_size(str) + acc
       end)
       |> Kernel.+(content_length)
     else

--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -22,7 +22,7 @@ defmodule Multipart.Part do
   """
   @spec binary_body(binary(), headers()) :: t()
   def binary_body(body, headers \\ []) when is_binary(body) do
-    content_length = String.length(body)
+    content_length = byte_size(body)
     %__MODULE__{body: body, content_length: content_length, headers: headers}
   end
 

--- a/test/multipart_test.exs
+++ b/test/multipart_test.exs
@@ -19,7 +19,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == byte_size(expected_output)
   end
 
   test "building a message of file parts" do
@@ -34,7 +34,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == byte_size(expected_output)
   end
 
   test "building a message of text form-data parts" do
@@ -49,7 +49,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == byte_size(expected_output)
   end
 
   test "building a message of file form-data parts" do
@@ -74,7 +74,7 @@ defmodule MultipartTest do
     assert output == expected_output
 
     content_length = Multipart.content_length(multipart)
-    assert content_length == String.length(expected_output)
+    assert content_length == byte_size(expected_output)
   end
 
   test "building a message preserves original line breaks" do


### PR DESCRIPTION
We were incorrectly using String.length, which returns graphemes. [The spec][1] says to use bytes.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length