### PR TITLE
Configurable disposition header

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.3-otp-24
+erlang 24.3


### PR DESCRIPTION
🖖 Thanks for your package ❤️

I needed to configure the  `content-disposition` header for `text_field/3` but it's actually sent twice when configured. This PR handles that case.