### PR TITLE
Fix deprecated File.stream!(file, options, line_or_bytes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.14.x
-            otp: 25.x
+          - elixir: 1.16.x
+            otp: 26.x
             check_formatted: true
-          - elixir: 1.13.x
-            otp: 24.x
-          - elixir: 1.12.x
-            otp: 24.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.0-otp-25
-erlang 25.0.4
+elixir 1.16.1-otp-26
+erlang 26.2.1

--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -35,7 +35,7 @@ defmodule Multipart.Part do
   @spec file_body(String.t(), headers()) :: t()
   def file_body(path, headers \\ []) do
     %File.Stat{size: size} = File.stat!(path)
-    file_stream = File.stream!(path, [{:read_ahead, 4096}], 1024)
+    file_stream = File.stream!(path, 1024, [{:read_ahead, 4096}])
 
     %__MODULE__{body: file_stream, content_length: size, headers: headers}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Multipart.MixProject do
     [
       app: :multipart,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.16",
       name: "Multipart",
       source_url: "https://github.com/breakroom/multipart",
       description: "Multipart message generator",


### PR DESCRIPTION
Hello there, I recently updated an application of mine to Elixir 1.16 and I saw that `File.stream!(file, options, line_or_bytes)` is deprecated.

See https://hexdocs.pm/elixir/1.16.1/changelog.html#3-soft-deprecations-no-warnings-emitted

I have no idea how to keep supporting older versions so I changed the Elixir version requirement