### PR TITLE
fix: dialyzer errors on Elixir 1.16

### DIFF
--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -35,7 +35,7 @@ defmodule Multipart.Part do
   @spec file_body(String.t(), headers()) :: t()
   def file_body(path, headers \\ []) do
     %File.Stat{size: size} = File.stat!(path)
-    file_stream = File.stream!(path, 1024)
+    file_stream = file_stream!(path, 1024)
 
     %__MODULE__{body: file_stream, content_length: size, headers: headers}
   end
@@ -179,5 +179,11 @@ defmodule Multipart.Part do
 
   defp maybe_add_filename_directive(directives, false, _path) do
     directives
+  end
+
+  if Version.compare(System.version(), "1.16.0") in [:gt, :eq] do
+    defp file_stream!(path, bytes), do: File.stream!(path, bytes)
+  else
+    defp file_stream!(path, bytes), do: File.stream!(path, [], bytes)
   end
 end

--- a/lib/multipart/part.ex
+++ b/lib/multipart/part.ex
@@ -35,7 +35,7 @@ defmodule Multipart.Part do
   @spec file_body(String.t(), headers()) :: t()
   def file_body(path, headers \\ []) do
     %File.Stat{size: size} = File.stat!(path)
-    file_stream = File.stream!(path, [{:read_ahead, 4096}], 1024)
+    file_stream = File.stream!(path, 1024)
 
     %__MODULE__{body: file_stream, content_length: size, headers: headers}
   end


### PR DESCRIPTION
Even though the code still works, dialyzer fails when using Elixir 1.16.

The fix is the same as described in this comment: https://github.com/elixir-lang/elixir/issues/13212#issuecomment-1871339145. I’ve removed the `:read_ahead` option as I understand Elixir will add it with a reasonable value by default. Let me know your thoughts about this.
